### PR TITLE
New visualization options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.9.0
         with:
-          dotnet-version: 6.x.x
+          dotnet-version: 7.x.x
         
       - name: Build
         run: |
-          dotnet publish ./src/qest/ -o ./pub --runtime linux-x64 -c Release --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
-          dotnet publish ./src/qest/ -o ./pub --runtime win-x64 -c Release --self-contained true /p:PublishSingleFile=true /p:PublishTrimmed=true
+          dotnet publish ./src/qest/ -o ./pub --runtime linux-x64 -c Release --self-contained true /p:PublishSingleFile=true
+          dotnet publish ./src/qest/ -o ./pub --runtime win-x64 -c Release --self-contained true /p:PublishSingleFile=true
           
       - name: Create Packages
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,5 @@ FodyWeavers.xsd
 PublishProfiles
 
 launchSettings.json
+
+Taskfile.yml

--- a/Taskfile_dist.yml
+++ b/Taskfile_dist.yml
@@ -1,0 +1,48 @@
+# https://taskfile.dev
+
+version: '3'
+
+tasks:
+  build:
+    desc: build project
+    cmds:
+      - dotnet build ./src/qest/
+  build:binaries:
+    desc: build binaries
+    deps:
+      - build
+    cmds:
+      - dotnet publish ./src/qest/ --runtime win-x64 -c Release --self-contained true /p:PublishSingleFile=true
+      - dotnet publish ./src/qest/ --runtime linux-x64 -c Release --self-contained true /p:PublishSingleFile=true
+  build:docker-bundle:
+    desc: build docker bundle image for local use
+    deps:
+      - build
+    cmds:
+      - docker build -t qest:bundle-dev -f bundle.dockerfile .
+  build:docker-standalone:
+    desc: build docker standalone image for local use
+    deps:
+      - build
+    cmds:
+      - docker build -t qest:standalone-dev -f standalone.dockerfile .
+  build:all:
+    desc: build binaries and docker images
+    cmds:
+      - task: build-binaries
+      - task: build-docker-standalone
+      - task: build-docker-bundle
+
+  samples:build:
+    desc: build sampleDb image
+    deps:
+      - build:docker-bundle
+    cmds:
+      - docker build -t qest:samples ./samples/
+
+  samples:run:
+    desc: run samples
+    deps:
+      - samples:build
+    cmds:
+      - docker run --rm -t qest:samples

--- a/bundle.dockerfile
+++ b/bundle.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
 
 LABEL org.opencontainers.image.source=https://github.com/geims83/qest
 
@@ -32,5 +32,5 @@ WORKDIR /
 
 ENTRYPOINT ["sh", "-c", "( /opt/mssql/bin/sqlservr & ) | grep -q \"Service Broker manager has started\" \
     && PATH='$PATH':/app \
-    && sqlpackage /a:Publish /sf:db/${DACPAC}.dacpac /tsn:. /tdn:$DACPAC /tu:sa /tp:$SA_PASSWORD \
+    && sqlpackage /a:Publish /sf:db/${DACPAC}.dacpac /tsn:. /tdn:$DACPAC /tu:sa /tp:$SA_PASSWORD /TargetEncryptConnection:False \
     && qest run --folder tests --tcs \"Server=localhost,1433;Initial Catalog=${DACPAC};User Id=sa;Password=${SA_PASSWORD}\" -o tree"]

--- a/bundle.dockerfile
+++ b/bundle.dockerfile
@@ -33,4 +33,4 @@ WORKDIR /
 ENTRYPOINT ["sh", "-c", "( /opt/mssql/bin/sqlservr & ) | grep -q \"Service Broker manager has started\" \
     && PATH='$PATH':/app \
     && sqlpackage /a:Publish /sf:db/${DACPAC}.dacpac /tsn:. /tdn:$DACPAC /tu:sa /tp:$SA_PASSWORD \
-    && qest run --folder tests --tcs \"Server=localhost,1433;Initial Catalog=${DACPAC};User Id=sa;Password=${SA_PASSWORD}\""]
+    && qest run --folder tests --tcs \"Server=localhost,1433;Initial Catalog=${DACPAC};User Id=sa;Password=${SA_PASSWORD}\" -o tree"]

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /build
 COPY ./sampleDb .
 RUN dotnet build . -c Release -o /dacpac
 
-FROM qest:bundle
+FROM qest:bundle-dev
 
 ENV DACPAC=sampleDb
 

--- a/samples/tests/sampleSp.yml
+++ b/samples/tests/sampleSp.yml
@@ -102,6 +102,48 @@
               - name: TimeValue
                 type: Time
         returnCode: 1
+    - name: Test Error
+      command:
+        commandText: dbo.SampleSp
+        parameters:
+          name: "NoMatchData"
+          newValue: a
+      results:
+        resultSets:
+          - name: sampleSpRS1
+            rowNumber: 1
+            columns:
+              - name: Name
+                type: NVarChar
+              - name: BitValue
+                type: Bit
+              - name: TinyIntValue
+                type: TinyInt
+              - name: SmallintValue
+                type: SmallInt
+              - name: IntValue
+                type: Int
+              - name: BigIntValue
+                type: BigInt
+              - name: FloatValue
+                type: Float
+              - name: RealtValue
+                type: Real
+              - name: DecimalValue
+                type: Decimal
+              - name: MoneyValue
+                type: Money
+              - name: DateTimeValue
+                type: DateTime
+              - name: DateTime2Value
+                type: DateTime2
+              - name: DateTimeOffsetValue
+                type: DateTimeOffset
+              - name: DateValue
+                type: Date
+              - name: TimeValue
+                type: Time
+        returnCode: 0
   after:
     - type: File
       values:

--- a/samples/tests/sampleSp.yml
+++ b/samples/tests/sampleSp.yml
@@ -60,6 +60,14 @@
         - sqlQuery: SELECT COUNT(*) FROM dbo.SampleTable WHERE [IntValue] = {newValueVar}
           scalarType: Int
           scalarValue: 1
+    - name: Test Error
+      command:
+        commandText: dbo.SampleSp
+        parameters:
+          name: "NoMatchData"
+          newValue: a
+      results:
+        returnCode: 0
     - name: Test KO
       command:
         commandText: dbo.SampleSp
@@ -102,48 +110,6 @@
               - name: TimeValue
                 type: Time
         returnCode: 1
-    - name: Test Error
-      command:
-        commandText: dbo.SampleSp
-        parameters:
-          name: "NoMatchData"
-          newValue: a
-      results:
-        resultSets:
-          - name: sampleSpRS1
-            rowNumber: 1
-            columns:
-              - name: Name
-                type: NVarChar
-              - name: BitValue
-                type: Bit
-              - name: TinyIntValue
-                type: TinyInt
-              - name: SmallintValue
-                type: SmallInt
-              - name: IntValue
-                type: Int
-              - name: BigIntValue
-                type: BigInt
-              - name: FloatValue
-                type: Float
-              - name: RealtValue
-                type: Real
-              - name: DecimalValue
-                type: Decimal
-              - name: MoneyValue
-                type: Money
-              - name: DateTimeValue
-                type: DateTime
-              - name: DateTime2Value
-                type: DateTime2
-              - name: DateTimeOffsetValue
-                type: DateTimeOffset
-              - name: DateValue
-                type: Date
-              - name: TimeValue
-                type: Time
-        returnCode: 0
   after:
     - type: File
       values:

--- a/src/qest/Commands/RunCommand.cs
+++ b/src/qest/Commands/RunCommand.cs
@@ -30,10 +30,15 @@ namespace qest.Commands
 
             private List<string> AllowedOutput = new List<string>(){"console", "tree"};
             
-            [Description($"Output format: console / tree")]
+            [Description($"Output format: console | tree")]
             [CommandOption("-o|--output <OUTPUTFORMAT>")]
             [DefaultValue("console")]
             public string OutputFormat { get; init; }
+
+            [Description("Verbose: visualize all output, instead of only errors")]
+            [CommandOption("-v|--verbose")]
+            [DefaultValue(false)]
+            public bool Verbose { get; init; }
 
 
             public override ValidationResult Validate()
@@ -102,7 +107,7 @@ namespace qest.Commands
                 visualizer = new ConsoleVisualizer<MsSqlConnector>(TestCollection, settings.ConnectionString);
 
 
-            int exitCode = await visualizer.RunAllAsync();
+            int exitCode = await visualizer.RunAllAsync(settings.Verbose);
             return exitCode;
         }
     }

--- a/src/qest/Utils/ExtensionMethods.cs
+++ b/src/qest/Utils/ExtensionMethods.cs
@@ -41,13 +41,5 @@ namespace qest
 
             return message;
         }
-
-        internal static void RemoveLast<T>(this List<T> list)
-        {
-            if (list.Count > 0)
-                list.RemoveAt(list.Count-1);
-            else
-                throw new System.NotSupportedException();
-        }
     }
 }

--- a/src/qest/Visualizers/ConsoleVisualizer.cs
+++ b/src/qest/Visualizers/ConsoleVisualizer.cs
@@ -12,6 +12,7 @@ namespace qest.Visualizers
 
         private Test Test;
         private bool Pass;
+        private bool Verbose;
 
         private const string objectStyle_l1 = "blue";
         private const string objectStyle_l2 = "cornflowerblue";
@@ -37,8 +38,10 @@ namespace qest.Visualizers
             LogHierarchy = new();
         }
 
-        public async Task<int> RunAllAsync()
+        public async Task<int> RunAllAsync(bool verbose)
         {
+            Verbose = verbose;
+
             int exitCode = 0;
 
             AnsiConsole.MarkupLine($"{TestCollection.Count} tests loaded");
@@ -92,9 +95,9 @@ namespace qest.Visualizers
             }
 
             if (Pass)
-                LogConsole("OK".EscapeAndAddStyles($"bold {okStyle}"));
+                LogConsole("OK".EscapeAndAddStyles($"bold {okStyle}"), true);
             else
-                LogConsole("KO!".EscapeAndAddStyles(errorStyle));
+                LogConsole("KO!".EscapeAndAddStyles(errorStyle), true);
 
             return Pass;
         }
@@ -133,7 +136,7 @@ namespace qest.Visualizers
 
                         if (currentResult == null)
                         {
-                            LogConsole($"Not found".EscapeAndAddStyles(errorStyle));
+                            LogConsoleError($"Not found".EscapeAndAddStyles(errorStyle));
                             Pass = false;
                             LogHierarchy.RemoveLast();
                             continue;
@@ -143,7 +146,7 @@ namespace qest.Visualizers
                         {
                             if (expectedResult.RowNumber != currentResult.Rows.Count)
                             {
-                                LogConsole($"Rows: {currentResult.Rows.Count} != {expectedResult.RowNumber}".EscapeAndAddStyles(errorStyle));
+                                LogConsoleError($"Rows: {currentResult.Rows.Count} != {expectedResult.RowNumber}".EscapeAndAddStyles(errorStyle));
                                 Pass = false;
                                 LogHierarchy.RemoveLast();
                                 continue;
@@ -167,7 +170,7 @@ namespace qest.Visualizers
 
                         if (currentResult is null)
                         {
-                            LogConsole("Null output".EscapeAndAddStyles(errorStyle));
+                            LogConsoleError("Null output".EscapeAndAddStyles(errorStyle));
                             Pass = false;
                             LogHierarchy.RemoveLast();
                             continue;
@@ -178,7 +181,7 @@ namespace qest.Visualizers
                             var parameterType = Utils.MapQestTypeToInternal(expectedResult.Type);
                             if (!Convert.ChangeType(expectedResult.Value, parameterType).Equals(Convert.ChangeType(currentResult, parameterType)))
                             {
-                                LogConsole($"{currentResult} != {expectedResult.Value}".EscapeAndAddStyles(errorStyle));
+                                LogConsoleError($"{currentResult} != {expectedResult.Value}".EscapeAndAddStyles(errorStyle));
                                 Pass = false;
                                 LogHierarchy.RemoveLast();
                                 continue;
@@ -209,14 +212,14 @@ namespace qest.Visualizers
 
                         if (!currentResult.HasValue)
                         {
-                            LogConsole("Null output".EscapeAndAddStyles(errorStyle));
+                            LogConsoleError("Null output".EscapeAndAddStyles(errorStyle));
                             Pass = false;
                         }
                         else
                         {
                             if (expectedResult != Convert.ToInt32(currentResult.Value))
                             {
-                                LogConsole($"{currentResult.Value} != {expectedResult}".EscapeAndAddStyles(errorStyle));
+                                LogConsoleError($"{currentResult.Value} != {expectedResult}".EscapeAndAddStyles(errorStyle));
                                 Pass = false;
                             }
                             else
@@ -248,7 +251,7 @@ namespace qest.Visualizers
 
                     if (currentResult is null)
                     {
-                        LogConsole($"NULL != {assertScalarValue}".EscapeAndAddStyles(errorStyle));
+                        LogConsoleError($"NULL != {assertScalarValue}".EscapeAndAddStyles(errorStyle));
                         Pass = false;
                     }
                     else
@@ -261,7 +264,7 @@ namespace qest.Visualizers
                             LogConsole($"{currentResult} == {assertScalarValue}".EscapeAndAddStyles(okStyle));
                         else
                         {
-                            LogConsole($"{currentResult} != {assertScalarValue}".EscapeAndAddStyles(errorStyle));
+                            LogConsoleError($"{currentResult} != {assertScalarValue}".EscapeAndAddStyles(errorStyle));
                             Pass = false;
                         }
                     }
@@ -293,10 +296,16 @@ namespace qest.Visualizers
             AnsiConsole.WriteException(ex);
         }
 
-        private void LogConsole(string message)
+        private void LogConsole(string message, bool forceOutput = false)
         {
-            string prfx = string.Join(consoleSeparator, LogHierarchy);
-            AnsiConsole.MarkupLine($"{prfx}{consoleSeparator}{message}");
+            if (Verbose || forceOutput)
+            {
+                string prfx = string.Join(consoleSeparator, LogHierarchy);
+                AnsiConsole.MarkupLine($"{prfx}{consoleSeparator}{message}");
+            }
         }
+
+        private void LogConsoleError(string message) => LogConsole(message, true);
+        
     }
 }

--- a/src/qest/Visualizers/ConsoleVisualizer.cs
+++ b/src/qest/Visualizers/ConsoleVisualizer.cs
@@ -308,4 +308,15 @@ namespace qest.Visualizers
         private void LogConsoleError(string message) => LogConsole(message, true);
         
     }
+
+    file static class ExtensionMethods
+    {
+        internal static void RemoveLast<T>(this List<T> list)
+        {
+            if (list.Count > 0)
+                list.RemoveAt(list.Count - 1);
+            else
+                throw new System.NotSupportedException();
+        }
+    }
 }

--- a/src/qest/Visualizers/IVisualizer.cs
+++ b/src/qest/Visualizers/IVisualizer.cs
@@ -4,6 +4,6 @@ namespace qest.Visualizers
 {
     public interface IVisualizer
     {
-        Task<int> RunAllAsync();
+        Task<int> RunAllAsync(bool verbose);
     }
 }

--- a/src/qest/qest.csproj
+++ b/src/qest/qest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.5</Version>
+    <Version>0.9.6</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="YamlDotNet" Version="12.0.1" />
+    <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>
 
 </Project>

--- a/standalone.dockerfile
+++ b/standalone.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
 
 LABEL org.opencontainers.image.source=https://github.com/geims83/qest
 
@@ -8,7 +8,7 @@ RUN dotnet restore /src -r linux-x64
 
 RUN dotnet publish /src/qest/ -o /output --runtime linux-x64 -c Release --self-contained false --no-restore
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:7.0
 
 WORKDIR /app
 COPY --from=build /output/ .


### PR DESCRIPTION
The default output now shows only passed tests and errors, when they happen.
There are two new command options for **run**:
- **-output**: _console_ or _tree_
- **-v**: verbose mode (shows all output instead of only pass/errors)