### PR TITLE
Updates

### DIFF
--- a/Taskfile_dist.yml
+++ b/Taskfile_dist.yml
@@ -44,4 +44,4 @@ tasks:
     deps:
       - samples:build
     cmds:
-      - docker run -t qest:samples
+      - docker run --rm -t qest:samples

--- a/Taskfile_dist.yml
+++ b/Taskfile_dist.yml
@@ -44,4 +44,4 @@ tasks:
     deps:
       - samples:build
     cmds:
-      - docker run --rm -t qest:samples
+      - docker run -t qest:samples

--- a/bundle.dockerfile
+++ b/bundle.dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
-LABEL org.opencontainers.image.source=https://github.com/geims83/qest
+LABEL org.opencontainers.image.source=https://github.com/gicastel/qest
 
 COPY ./src ./src
 RUN dotnet publish /src/qest/ -o /output --runtime linux-x64 -c Release --self-contained true /p:PublishSingleFile=true
@@ -9,8 +9,8 @@ FROM mcr.microsoft.com/mssql/server:2022-latest AS mssql
 USER root
 
 # env vars needed by the mssql image
-ENV ACCEPT_EULA Y
-ENV SA_PASSWORD qestDbSecurePassword27!
+ENV ACCEPT_EULA=Y
+ENV SA_PASSWORD=qestDbSecurePassword27!
 
 WORKDIR /app
 COPY --from=build /output/ .
@@ -33,4 +33,4 @@ WORKDIR /
 ENTRYPOINT ["sh", "-c", "( /opt/mssql/bin/sqlservr & ) | grep -q \"Service Broker manager has started\" \
     && PATH='$PATH':/app \
     && sqlpackage /a:Publish /sf:db/${DACPAC}.dacpac /tsn:. /tdn:$DACPAC /tu:sa /tp:$SA_PASSWORD /TargetEncryptConnection:False \
-    && qest run --folder tests --tcs \"Server=localhost,1433;Initial Catalog=${DACPAC};User Id=sa;Password=${SA_PASSWORD}\" -v"]
+    && qest run --folder tests --tcs \"Server=localhost,1433;Initial Catalog=${DACPAC};User Id=sa;Password=${SA_PASSWORD}\" --verbose"]

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /build
 COPY ./sampleDb .

--- a/samples/sampleDb/sampleDb.csproj
+++ b/samples/sampleDb/sampleDb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.SqlProj/2.2.0">
+<Project Sdk="MSBuild.Sdk.SqlProj/2.6.1">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/qest/Commands/RunCommand.cs
+++ b/src/qest/Commands/RunCommand.cs
@@ -36,7 +36,7 @@ namespace qest.Commands
             public string OutputFormat { get; init; }
 
             [Description("Verbose: visualize all output, instead of only errors")]
-            [CommandOption("-v|--verbose")]
+            [CommandOption("-e|--verbose")]
             [DefaultValue(false)]
             public bool Verbose { get; init; }
 

--- a/src/qest/qest.csproj
+++ b/src/qest/qest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.9</Version>
+    <Version>0.10.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="YamlDotNet" Version="12.0.2" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="YamlDotNet" Version="15.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/qest/qest.sln
+++ b/src/qest/qest.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.001.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "qest", "qest.csproj", "{D8AC502F-6226-4CDD-B7EE-40EE1C930790}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8AC502F-6226-4CDD-B7EE-40EE1C930790}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8AC502F-6226-4CDD-B7EE-40EE1C930790}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AC502F-6226-4CDD-B7EE-40EE1C930790}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8AC502F-6226-4CDD-B7EE-40EE1C930790}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1126725C-967B-4964-8919-71CC0920FA02}
+	EndGlobalSection
+EndGlobal

--- a/standalone.dockerfile
+++ b/standalone.dockerfile
@@ -1,6 +1,6 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
-LABEL org.opencontainers.image.source=https://github.com/geims83/qest
+LABEL org.opencontainers.image.source=https://github.com/gicastel/qest
 
 COPY ./src ./src
 
@@ -8,7 +8,7 @@ RUN dotnet restore /src -r linux-x64
 
 RUN dotnet publish /src/qest/ -o /output --runtime linux-x64 -c Release --self-contained false --no-restore
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0
+FROM mcr.microsoft.com/dotnet/runtime:8.0
 
 WORKDIR /app
 COPY --from=build /output/ .


### PR DESCRIPTION
**BREAKING CHANGE**: the verbose short flag `-v` was clashing with the default version parameter, so I had to change it to `-e | --verbose`
Also: Updated framework, packages, dockerfiles labels